### PR TITLE
🦄Add (Query Params)

### DIFF
--- a/examples/start.go
+++ b/examples/start.go
@@ -13,12 +13,12 @@ func main() {
 		p := request.GetParam("name")
 		response.Send(300, p)
 	})
-	router.Get("/hello/?name", func(response *fiable.Response, request *fiable.Request) {
+	router.Get("/hello/?", func(response *fiable.Response, request *fiable.Request) {
 		type hello struct {
 			Name string `json:"name"`
 			Age  int    `json:"age"`
 		}
-		q := request.Ref.URL.Query()
+		q := request.GetQuery("name")
 		fmt.Println(q)
 		response.Json(&hello{Name: "totu", Age: 15})
 	})

--- a/request.go
+++ b/request.go
@@ -2,8 +2,10 @@ package fiable
 
 import (
 	"encoding/json"
+	"log"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 	// "strings"
 )
@@ -43,6 +45,7 @@ type Request struct {
 	method     string
 	url        string
 	Params     []*Param
+	query      url.Values
 	header     *ReqHeader
 	json       *json.Decoder
 	props      *map[string]interface{}
@@ -55,6 +58,7 @@ func request(httRequest *http.Request, props *map[string]interface{}) *Request {
 	req.fileReader = nil
 	req.method = httRequest.Proto
 	req.props = props
+	req.query = httRequest.URL.Query()
 	for i, v := range httRequest.Header {
 		req.header.Set(strings.ToLower(i), strings.Join(v, ","))
 	}
@@ -105,4 +109,11 @@ func (r *Request) Json() *json.Decoder {
 
 func (r *Request) Method() string {
 	return r.method
+}
+
+func (r *Request) GetQuery(key string) string {
+	if r.query[key][0] == "" {
+		log.Panic("No query param found with given key")
+	}
+	return r.query[key][0]
 }

--- a/response.go
+++ b/response.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Response struct {
-	Ref      http.ResponseWriter
-	url      string
-	method   string
-	ended    bool
-	header   *Header
+	Ref    http.ResponseWriter
+	url    string
+	method string
+	ended  bool
+	header *Header
+
 	props    *map[string]interface{}
 	host     string
 	HasEnded bool
@@ -26,6 +27,7 @@ func response(rs http.ResponseWriter, req *http.Request, props *map[string]inter
 	res.url = req.URL.Path
 	res.method = req.Method
 	res.host = req.Host
+
 	res.props = props
 
 	return res

--- a/router.go
+++ b/router.go
@@ -1,6 +1,7 @@
 package fiable
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -43,7 +44,8 @@ func RegexPath(path string) (string, []string) {
 		}
 
 	}
-	regexPath = "^" + strings.Join(items, `\/`) + `/?` + "$"
+	regexPath = "^" + strings.Join(items, `\/`) + "$"
+	fmt.Print(regexPath)
 	return regexPath, Params
 }
 


### PR DESCRIPTION
Added query params .
Now you can get query params from the path example
```go
app.Get("/api/?", func(response *fiable.Response, request *fiable.Request) {
		p := request.GetQuery("QUERYNAME") //query name like name etc
		response.Send(300, p)
})
```
Requested path : api?name=abc
Query Param : abc
Key : Name